### PR TITLE
Add --debug flag to see stack of exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--debug` flag to see stack of exceptions, [PR-7](https://github.com/panda-official/DriftCLI/pull/7)
+
 ## [0.4.0] - 2023-03-15
 
 ### Added

--- a/drift_cli/alias.py
+++ b/drift_cli/alias.py
@@ -63,7 +63,7 @@ def add(
     if bucket is None:
         bucket = click.prompt("Bucket", type=str, default="data")
 
-    with error_handle():
+    with error_handle(ctx.obj["debug"]):
         entry = Alias(address=address, password=password, bucket=bucket)
 
         conf.aliases[name] = entry

--- a/drift_cli/cli.py
+++ b/drift_cli/cli.py
@@ -25,11 +25,18 @@ from drift_cli.config import write_config, Config
     type=int,
     help="Number of parallel tasks to use, defaults to 10",
 )
+@click.option(
+    "--debug",
+    "-d",
+    is_flag=True,
+    help="Enable debug logging",
+)
 @click.pass_context
 def cli(
     ctx,
     config: Optional[Path] = None,
     parallel: Optional[int] = None,
+    debug: bool = False,
 ):
     """CLI client for PANDA | Drift Platform"""
     if config is None:
@@ -43,6 +50,7 @@ def cli(
 
     ctx.obj["config_path"] = config
     ctx.obj["parallel"] = parallel
+    ctx.obj["debug"] = debug
 
 
 cli.add_command(alias, "alias")

--- a/drift_cli/export.py
+++ b/drift_cli/export.py
@@ -91,7 +91,7 @@ def raw(
     run = loop.run_until_complete
     client = DriftClient(alias.address, alias.password, loop=loop)
 
-    with error_handle():
+    with error_handle(ctx.obj["debug"]):
         run(
             export_raw(
                 client,

--- a/drift_cli/utils/error.py
+++ b/drift_cli/utils/error.py
@@ -7,10 +7,14 @@ from drift_cli.utils.consoles import error_console
 
 
 @contextmanager
-def error_handle():
-    """Wrap try-catch block and print errorr"""
-    try:
+def error_handle(debug: bool):
+    """Wrap try-catch block and print error"""
+    if debug:
+        # If debug is enabled, we don't want to catch any errors and wrap them
         yield
-    except Exception as err:
-        error_console.print(f"[{type(err).__name__}] {err}")
-        raise Abort() from err
+    else:
+        try:
+            yield
+        except Exception as err:
+            error_console.print(f"[{type(err).__name__}] {err}")
+            raise Abort() from err

--- a/drift_cli/utils/helpers.py
+++ b/drift_cli/utils/helpers.py
@@ -46,12 +46,12 @@ def parse_path(path) -> Tuple[str, str]:
 
 
 async def read_topic(
-    pool: Executor,
-    client: DriftClient,
-    topic: str,
-    progress: Progress,
-    sem: Semaphore,
-    **kwargs,
+        pool: Executor,
+        client: DriftClient,
+        topic: str,
+        progress: Progress,
+        sem: Semaphore,
+        **kwargs,
 ):  # pylint: disable=too-many-locals
     """Read records from entry and show progress
     Args:
@@ -88,8 +88,11 @@ async def read_topic(
     def stop_signal():
         signal_queue.put_nowait("stop")
 
-    loop.add_signal_handler(signal.SIGINT, stop_signal)
-    loop.add_signal_handler(signal.SIGTERM, stop_signal)
+    try:
+        loop.add_signal_handler(signal.SIGINT, stop_signal)
+        loop.add_signal_handler(signal.SIGTERM, stop_signal)
+    except NotImplementedError:
+        error_console.print("Signals are not supported on this platform. No graceful shutdown possible.")
 
     packages = await loop.run_in_executor(
         pool, client.get_package_names, topic, start, stop
@@ -105,7 +108,7 @@ async def read_topic(
 
     packages = sorted(packages)
     for i in range(0, len(packages), parallel):
-        tasks = [_read_package(p) for p in packages[i : i + parallel]]
+        tasks = [_read_package(p) for p in packages[i: i + parallel]]
         results = await asyncio.gather(*tasks)
 
         for drift_pkg in results:
@@ -117,7 +120,7 @@ async def read_topic(
                 progress.update(
                     task,
                     description=f"Topic '{topic}' "
-                    f"(copied {count} packages ({pretty_size(exported_size)}), stopped",
+                                f"(copied {count} packages ({pretty_size(exported_size)}), stopped",
                     refresh=True,
                 )
                 return
@@ -138,8 +141,8 @@ async def read_topic(
             progress.update(
                 task,
                 description=f"Topic '{topic}' "
-                f"(copied {count} packages ({pretty_size(exported_size)}), "
-                f"speed {pretty_size(speed)}/s)",
+                            f"(copied {count} packages ({pretty_size(exported_size)}), "
+                            f"speed {pretty_size(speed)}/s)",
                 advance=timestamp - last_time,
                 refresh=True,
             )

--- a/drift_cli/utils/helpers.py
+++ b/drift_cli/utils/helpers.py
@@ -46,12 +46,12 @@ def parse_path(path) -> Tuple[str, str]:
 
 
 async def read_topic(
-        pool: Executor,
-        client: DriftClient,
-        topic: str,
-        progress: Progress,
-        sem: Semaphore,
-        **kwargs,
+    pool: Executor,
+    client: DriftClient,
+    topic: str,
+    progress: Progress,
+    sem: Semaphore,
+    **kwargs,
 ):  # pylint: disable=too-many-locals
     """Read records from entry and show progress
     Args:
@@ -92,7 +92,9 @@ async def read_topic(
         loop.add_signal_handler(signal.SIGINT, stop_signal)
         loop.add_signal_handler(signal.SIGTERM, stop_signal)
     except NotImplementedError:
-        error_console.print("Signals are not supported on this platform. No graceful shutdown possible.")
+        error_console.print(
+            "Signals are not supported on this platform. No graceful shutdown possible."
+        )
 
     packages = await loop.run_in_executor(
         pool, client.get_package_names, topic, start, stop
@@ -108,7 +110,7 @@ async def read_topic(
 
     packages = sorted(packages)
     for i in range(0, len(packages), parallel):
-        tasks = [_read_package(p) for p in packages[i: i + parallel]]
+        tasks = [_read_package(p) for p in packages[i : i + parallel]]
         results = await asyncio.gather(*tasks)
 
         for drift_pkg in results:
@@ -120,7 +122,7 @@ async def read_topic(
                 progress.update(
                     task,
                     description=f"Topic '{topic}' "
-                                f"(copied {count} packages ({pretty_size(exported_size)}), stopped",
+                    f"(copied {count} packages ({pretty_size(exported_size)}), stopped",
                     refresh=True,
                 )
                 return
@@ -141,8 +143,8 @@ async def read_topic(
             progress.update(
                 task,
                 description=f"Topic '{topic}' "
-                            f"(copied {count} packages ({pretty_size(exported_size)}), "
-                            f"speed {pretty_size(speed)}/s)",
+                f"(copied {count} packages ({pretty_size(exported_size)}), "
+                f"speed {pretty_size(speed)}/s)",
                 advance=timestamp - last_time,
                 refresh=True,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=40.8.0", "wheel"]
 [project]
 
 name = "drift-cli"
-version = "0.4.0"
+version = "0.5.0"
 description = "CLI client for PANDA | Drift Platform"
 requires-python = ">=3.8"
 readme = "README.md"


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

We catch all exception and print only its messages. However, we need more information sometimes for debugging.

### What is the new behavior?

Now, we have the `--debug` global flag to print full information about exceptions including the call stack 


### Does this PR introduce a breaking change?

No

### Other information:
