### PR TITLE
Minimal version of DriftPythonClient 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `--debug` flag to see stack of exceptions, [PR-7](https://github.com/panda-official/DriftCLI/pull/7)
 
+### Changed
+
+- Minimal version of DriftPythonClient 0.5.0, [PR-9](https://github.com/panda-official/DriftCLI/pull/9)
+
 ### Fixed
 
 - Skip packages with bad status during the export to JPEG, [PR-8](https://github.com/panda-official/DriftCLI/pull/8)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "drift-python-client~=0.4.1",
+    "drift-python-client~=0.5.0",
     "click~=8.1",
     "tomlkit~=0.11",
     "rich~=12.6",


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Dependency update

### What is the current behavior?

DriftPythonClient 0.4.1 with WaveletBuffer >= 0.4.0

### What is the new behavior?

DriftPythonClient 0.5.0 with WaveletBuffer >= 0.6.0


### Does this PR introduce a breaking change?

No

### Other information:
