### PR TITLE
DRIFT-613: Use new `Client.walk` method to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- DRIFT-613: Use new Client.walk method to improve performance, [PR-12](https://github.com/panda-official/DriftCLI/pull/12)
+
 ## 0.6.0 - 2023-04-12
 
 ## Added

--- a/drift_cli/export.py
+++ b/drift_cli/export.py
@@ -89,6 +89,7 @@ def raw(
 
     loop = asyncio.get_event_loop()
     run = loop.run_until_complete
+
     client = DriftClient(alias.address, alias.password, loop=loop)
 
     with error_handle(ctx.obj["debug"]):

--- a/drift_cli/export_impl/raw.py
+++ b/drift_cli/export_impl/raw.py
@@ -1,6 +1,6 @@
 """Export data"""
 import asyncio
-from concurrent.futures import ThreadPoolExecutor, Executor
+from concurrent.futures import ThreadPoolExecutor, Executor, ProcessPoolExecutor
 from pathlib import Path
 from typing import Optional, List, Tuple
 
@@ -209,7 +209,7 @@ async def export_raw(client: DriftClient, dest: str, parallel: int, **kwargs):
     """
     sem = asyncio.Semaphore(parallel)
     with Progress() as progress:
-        with ThreadPoolExecutor() as pool:
+        with ThreadPoolExecutor(max_workers=8) as pool:
             topics = filter_topics(client.get_topics(), kwargs.pop("topics", ""))
             task = _export_csv if kwargs.pop("csv", False) else _export_topic
             task = _export_jpeg if kwargs.pop("jpeg", False) else task

--- a/drift_cli/utils/helpers.py
+++ b/drift_cli/utils/helpers.py
@@ -10,7 +10,6 @@ from typing import Tuple, List
 
 from click import Abort
 from drift_client import DriftClient
-from drift_client.error import DriftClientError
 from rich.progress import Progress
 
 from drift_cli.config import read_config, Alias
@@ -101,7 +100,7 @@ async def read_topic(
 
         def _next():
             try:
-                return it.__next__()
+                return next(it)
             except StopIteration:
                 return None
 

--- a/drift_cli/utils/helpers.py
+++ b/drift_cli/utils/helpers.py
@@ -46,12 +46,12 @@ def parse_path(path) -> Tuple[str, str]:
 
 
 async def read_topic(
-        pool: Executor,
-        client: DriftClient,
-        topic: str,
-        progress: Progress,
-        sem: Semaphore,
-        **kwargs,
+    pool: Executor,
+    client: DriftClient,
+    topic: str,
+    progress: Progress,
+    sem: Semaphore,
+    **kwargs,
 ):  # pylint: disable=too-many-locals
     """Read records from entry and show progress
     Args:
@@ -84,7 +84,6 @@ async def read_topic(
     speed = 0
 
     async with sem:
-
         loop = asyncio.get_running_loop()
 
         def stop_signal():
@@ -99,6 +98,7 @@ async def read_topic(
             )
 
         it = client.walk(topic, start=start, stop=stop)
+
         def _next():
             try:
                 return it.__next__()
@@ -115,7 +115,7 @@ async def read_topic(
                 progress.update(
                     task,
                     description=f"Topic '{topic}' "
-                                f"(copied {count} packages ({pretty_size(exported_size)}), stopped",
+                    f"(copied {count} packages ({pretty_size(exported_size)}), stopped",
                     refresh=True,
                 )
                 return
@@ -134,8 +134,8 @@ async def read_topic(
             progress.update(
                 task,
                 description=f"Topic '{topic}' "
-                            f"(copied {count} packages ({pretty_size(exported_size)}), "
-                            f"speed {pretty_size(speed)}/s)",
+                f"(copied {count} packages ({pretty_size(exported_size)}), "
+                f"speed {pretty_size(speed)}/s)",
                 advance=timestamp - last_time,
                 refresh=True,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=40.8.0", "wheel"]
 [project]
 
 name = "drift-cli"
-version = "0.6.0"
+version = "0.7.0"
 description = "CLI client for PANDA | Drift Platform"
 requires-python = ">=3.8"
 readme = "README.md"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "drift-python-client~=0.5.0",
+    "drift-python-client~=0.6.0",
     "click~=8.1",
     "tomlkit~=0.11",
     "rich~=12.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ Blog = "https://dev.to/panda-official"
 drift-cli = "drift_cli:main"
 
 [tool.pylint.MASTER]
-good-names = "ls,rm,i"
+good-names = "ls,rm,i,it"
 disable = ["fixme", "duplicate-code"]
 extension-pkg-whitelist = "pydantic"
 load-plugins= "pylint_protobuf"

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -126,6 +126,8 @@ def _make_export_path() -> Path:
 
 
 class Iterator:
+    """Helper class to mock iterator"""
+
     def __init__(self, items):
         self.items = items[:]
 
@@ -188,7 +190,9 @@ def test__export_raw_data_no_timeseries(runner, client, conf, export_path):
     """Should skip no timeseries"""
     pkg = DriftPackage()
     pkg.meta.type = MetaInfo.IMAGE
-    client.walk.side_effect = [Iterator([DriftDataPackage(pkg.SerializeToString())])] * 2
+    client.walk.side_effect = [
+        Iterator([DriftDataPackage(pkg.SerializeToString())])
+    ] * 2
 
     result = runner(
         f"-c {conf} -p 1 export raw test {export_path} --start 2022-01-01 --stop 2022-01-02 --csv"
@@ -216,7 +220,7 @@ def test__export_raw_data_topics(runner, client, conf, export_path, topics, time
 
 @pytest.mark.usefixtures("set_alias")
 def test__export_raw_data_topics_jpeg(
-        runner, client, conf, export_path, topics, images
+    runner, client, conf, export_path, topics, images
 ):
     """Should exctract jpeg from wavelet buffers"""
     client.walk.side_effect = [Iterator(images), Iterator(images)]
@@ -244,8 +248,10 @@ def test__export_raw_jpeg_skip_bad_packages(runner, client, conf, export_path, t
     bad_package.id = 1
     bad_package.status = StatusCode.BAD
 
-    client.walk.side_effect = [Iterator([DriftDataPackage(bad_package.SerializeToString())] * 2),
-                               Iterator([DriftDataPackage(bad_package.SerializeToString())] * 2)]
+    client.walk.side_effect = [
+        Iterator([DriftDataPackage(bad_package.SerializeToString())] * 2),
+        Iterator([DriftDataPackage(bad_package.SerializeToString())] * 2),
+    ]
 
     result = runner(
         f"-c {conf} -p 1 export raw test {export_path} --start 2022-01-01 --stop 2022-01-02 "
@@ -262,7 +268,7 @@ def test__export_raw_jpeg_skip_bad_packages(runner, client, conf, export_path, t
 
 @pytest.mark.usefixtures("set_alias")
 def test__export_raw_jpeg_stacked_image(
-        runner, client, conf, export_path, topics, image_pkgs
+    runner, client, conf, export_path, topics, image_pkgs
 ):
     """Should export stacked image as few jpeg files"""
     for pkg in image_pkgs:


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

The CLI tool gets all timestamps for `export` request from InfluxDB , that takes time for long intervals.

### What is the new behavior?

Now, we use the `Client.walk` method to avoid requests to InfluxDB and iterate data in ReductStore quickly. 

### Does this PR introduce a breaking change?

No

### Other information:
