### PR TITLE
DRIFT-684: add `--with-metadata` flag for `export raw` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- DRIFT-684: `--with-metadata` flag for `export raw` command, [PR-13](https://github.com/panda-official/DriftCLI/pull/13)
+
 ## 0.6.1 - 2023-06-19
 
 ### Fixed

--- a/drift_cli/export.py
+++ b/drift_cli/export.py
@@ -56,6 +56,11 @@ def export():
     default=False,
     is_flag=True,
 )
+@click.option(
+    "--with-metadata/--no-with-metadata",
+    help="Export metadata along with the data",
+    default=False,
+)
 @click.pass_context
 def raw(
     ctx,
@@ -66,6 +71,7 @@ def raw(
     topics: str,
     csv: bool,
     jpeg: bool,
+    with_metadata: bool,
 ):  # pylint: disable=too-many-arguments
     """Export data from SRC bucket to DST folder
 
@@ -103,5 +109,6 @@ def raw(
                 stop=stop,
                 csv=csv,
                 jpeg=jpeg,
+                with_metadata=with_metadata,
             )
         )

--- a/drift_cli/export_impl/raw.py
+++ b/drift_cli/export_impl/raw.py
@@ -25,7 +25,7 @@ def _export_metadata_to_json(path: Path, pkg: DriftDataPackage):
             "published_time": pkg.publish_timestamp,
             "source_timestamp": pkg.source_timestamp,
         }
-        meta |= MessageToDict(pkg.meta, preserving_proto_field_name=True)
+        meta.update(MessageToDict(pkg.meta, preserving_proto_field_name=True))
 
         json.dump(meta, f, indent=2, sort_keys=False)
 

--- a/drift_cli/export_impl/raw.py
+++ b/drift_cli/export_impl/raw.py
@@ -1,18 +1,33 @@
 """Export data"""
 import asyncio
-from concurrent.futures import ThreadPoolExecutor, Executor, ProcessPoolExecutor
+import json
+from concurrent.futures import ThreadPoolExecutor, Executor
 from pathlib import Path
-from typing import Optional, List, Tuple
+from typing import List, Tuple
 
 import numpy as np
-from drift_client import DriftClient
+from drift_client import DriftClient, DriftDataPackage
 from drift_protocol.common import StatusCode
 from drift_protocol.meta import MetaInfo
+from google.protobuf.json_format import MessageToDict
 from rich.progress import Progress
 from wavelet_buffer import WaveletBuffer
-from wavelet_buffer.img import codecs, RgbJpeg, HslJpeg, GrayJpeg
+from wavelet_buffer.img import RgbJpeg, HslJpeg, GrayJpeg
 
 from drift_cli.utils.helpers import read_topic, filter_topics
+
+
+def _export_metadata_to_json(path: Path, pkg: DriftDataPackage):
+    with open(f"{path}/{pkg.package_id}.json", "w") as f:
+        meta = {
+            "id": pkg.package_id,
+            "status": pkg.status_code,
+            "published_time": pkg.publish_timestamp,
+            "source_timestamp": pkg.source_timestamp,
+        }
+        meta |= MessageToDict(pkg.meta, preserving_proto_field_name=True)
+
+        json.dump(meta, f, indent=2, sort_keys=False)
 
 
 def _tokenize(mask: str) -> List[Tuple[str, int]]:
@@ -80,6 +95,9 @@ async def _export_topic(
         with open(Path(dest) / topic / f"{package.package_id}.dp", "wb") as file:
             file.write(package.blob)
 
+        if kwargs.get("with_metadata", False):
+            _export_metadata_to_json(Path(dest) / topic, package)
+
 
 async def _export_jpeg(
     pool: Executor,
@@ -122,11 +140,14 @@ async def _export_jpeg(
             with open(Path(dest) / topic / name, "wb") as file:
                 file.write(img)
 
+        if kwargs.get("with_metadata", False):
+            _export_metadata_to_json(Path(dest) / topic, package)
+
 
 async def _export_csv(
     pool: Executor,
     client: DriftClient,
-    curren_topic: str,
+    topic: str,
     dest: str,
     progress: Progress,
     sem,
@@ -134,25 +155,23 @@ async def _export_csv(
 ):
     Path.mkdir(Path(dest), exist_ok=True, parents=True)
 
-    filename = Path(dest) / f"{curren_topic}.csv"
+    filename = Path(dest) / f"{topic}.csv"
     started = False
     first_timestamp = 0
     last_timestamp = 0
     count = 0
-    async for package, task in read_topic(
-        pool, client, curren_topic, progress, sem, **kwargs
-    ):
+    async for package, task in read_topic(pool, client, topic, progress, sem, **kwargs):
         meta = package.meta
         if meta.type != MetaInfo.TIME_SERIES:
             progress.update(
                 task,
-                description=f"[SKIPPED] Topic {curren_topic} is not a time series",
+                description=f"[SKIPPED] Topic {topic} is not a time series",
                 completed=True,
             )
             break
 
         if not started:
-            with open(Path(dest) / f"{curren_topic}.csv", "w") as file:
+            with open(Path(dest) / f"{topic}.csv", "w") as file:
                 file.write(" " * 256 + "\n")
             started = True
             first_timestamp = meta.time_series_info.start_timestamp.ToMilliseconds()
@@ -160,7 +179,7 @@ async def _export_csv(
             if last_timestamp != meta.time_series_info.start_timestamp.ToMilliseconds():
                 progress.update(
                     task,
-                    description=f"[ERROR] Topic {curren_topic} has gaps",
+                    description=f"[ERROR] Topic {topic} has gaps",
                     completed=True,
                 )
                 break
@@ -168,7 +187,7 @@ async def _export_csv(
         if package.status_code != 0:
             progress.update(
                 task,
-                description=f"[ERROR] Topic {curren_topic} has a bad package",
+                description=f"[ERROR] Topic {topic} has a bad package",
                 completed=True,
             )
             break
@@ -185,7 +204,7 @@ async def _export_csv(
             file.write(
                 ",".join(
                     [
-                        curren_topic,
+                        topic,
                         str(count),
                         str(first_timestamp),
                         str(last_timestamp),
@@ -204,15 +223,18 @@ async def export_raw(client: DriftClient, dest: str, parallel: int, **kwargs):
         start: Export records with timestamps newer than this time point in ISO format
         stop: Export records  with timestamps older than this time point in ISO format
         csv: Export data as CSV instead of raw data
-        topics: Export only 5
-        hese topics, separated by comma. You can use * as a wildcard
+        topics: Export only these topics, separated by comma. You can use * as a wildcard
+        with_meta: Export meta information in JSON format
     """
     sem = asyncio.Semaphore(parallel)
     with Progress() as progress:
         with ThreadPoolExecutor(max_workers=8) as pool:
             topics = filter_topics(client.get_topics(), kwargs.pop("topics", ""))
-            task = _export_csv if kwargs.pop("csv", False) else _export_topic
-            task = _export_jpeg if kwargs.pop("jpeg", False) else task
+            task = _export_csv if kwargs.get("csv", False) else _export_topic
+            task = _export_jpeg if kwargs.get("jpeg", False) else task
+
+            if kwargs.get("with_metadata", False) and kwargs.get("csv", False):
+                RuntimeError("Metadata export is not supported for CSV files")
 
             tasks = [
                 task(

--- a/drift_cli/utils/helpers.py
+++ b/drift_cli/utils/helpers.py
@@ -10,6 +10,7 @@ from typing import Tuple, List
 
 from click import Abort
 from drift_client import DriftClient
+from drift_client.error import DriftClientError
 from rich.progress import Progress
 
 from drift_cli.config import read_config, Alias
@@ -102,6 +103,8 @@ async def read_topic(
             try:
                 return next(it)
             except StopIteration:
+                return None
+            except DriftClientError:
                 return None
 
         while True:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=40.8.0", "wheel"]
 [project]
 
 name = "drift-cli"
-version = "0.6.1"
+version = "0.7.0"
 description = "CLI client for PANDA | Drift Platform"
 requires-python = ">=3.8"
 readme = "README.md"

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -166,7 +166,8 @@ def test__export_raw_data_with_metadata(
     """Test export raw data with metadata"""
     client.walk.side_effect = [Iterator(timeseries), Iterator(timeseries)]
     result = runner(
-        f"-c {conf} -p 2 export raw test {export_path} --start 2022-01-01 --stop 2022-01-02 --with-metadata"
+        f"-c {conf} -p 2 export raw test {export_path} --start 2022-01-01 "
+        f"--stop 2022-01-02 --with-metadata"
     )
     assert f"Topic '{topics[0]}' (copied 2 packages (943 B)" in result.output
     assert f"Topic '{topics[1]}' (copied 2 packages (943 B)" in result.output
@@ -177,8 +178,8 @@ def test__export_raw_data_with_metadata(
     assert (export_path / topics[1] / "1.json").exists()
     assert (export_path / topics[1] / "2.json").exists()
 
-    with open(export_path / topics[0] / "1.json") as f:
-        metadata = json.load(f)
+    with open(export_path / topics[0] / "1.json", encoding="utf-8") as file:
+        metadata = json.load(file)
         assert metadata == {
             "id": 1,
             "published_time": 0.0,

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -1,4 +1,6 @@
 """Export data from SRC bucket to DST bucket"""
+import json
+
 # pylint: disable=too-many-arguments
 import shutil
 from pathlib import Path
@@ -158,6 +160,38 @@ def test__export_raw_data(runner, client, conf, export_path, topics, timeseries)
 
 
 @pytest.mark.usefixtures("set_alias")
+def test__export_raw_data_with_metadata(
+    runner, client, conf, export_path, topics, timeseries
+):
+    """Test export raw data with metadata"""
+    client.walk.side_effect = [Iterator(timeseries), Iterator(timeseries)]
+    result = runner(
+        f"-c {conf} -p 2 export raw test {export_path} --start 2022-01-01 --stop 2022-01-02 --with-metadata"
+    )
+    assert f"Topic '{topics[0]}' (copied 2 packages (943 B)" in result.output
+    assert f"Topic '{topics[1]}' (copied 2 packages (943 B)" in result.output
+
+    assert result.exit_code == 0
+    assert (export_path / topics[0] / "1.json").exists()
+    assert (export_path / topics[0] / "2.json").exists()
+    assert (export_path / topics[1] / "1.json").exists()
+    assert (export_path / topics[1] / "2.json").exists()
+
+    with open(export_path / topics[0] / "1.json") as f:
+        metadata = json.load(f)
+        assert metadata == {
+            "id": 1,
+            "published_time": 0.0,
+            "source_timestamp": 0.0,
+            "status": 0,
+            "time_series_info": {
+                "start_timestamp": "1970-01-01T00:00:00.001Z",
+                "stop_timestamp": "1970-01-01T00:00:00.002Z",
+            },
+        }
+
+
+@pytest.mark.usefixtures("set_alias")
 def test__export_raw_data_as_csv(runner, client, conf, export_path, topics, timeseries):
     """Test export raw data as csv"""
     client.walk.side_effect = [Iterator(timeseries), Iterator(timeseries)]
@@ -239,6 +273,44 @@ def test__export_raw_data_topics_jpeg(
     img.import_from_file(
         str(export_path / topics[1] / "2.jpeg"), denoise.Null(), codecs.RgbJpeg()
     )
+
+
+@pytest.mark.usefixtures("set_alias")
+def test__export_raw_data_topics_jpeg_with_metadata(
+    runner, client, conf, export_path, topics, images
+):
+    """Should exctract jpeg from wavelet buffers with metadata"""
+    client.walk.side_effect = [Iterator(images), Iterator(images)]
+    result = runner(
+        f"-c {conf} -p 1 export raw test {export_path} --start 2022-01-01 --stop 2022-01-02 "
+        f"--jpeg "
+        f"--with-metadata"
+    )
+
+    assert f"Topic '{topics[0]}' (copied 2 packages (241 KB)" in result.output
+    assert result.exit_code == 0
+
+    img = WaveletImage([100, 100], 3, 1, WaveletType.DB1)
+    img.import_from_file(
+        str(export_path / topics[0] / "1.jpeg"), denoise.Null(), codecs.RgbJpeg()
+    )
+    img.import_from_file(
+        str(export_path / topics[1] / "2.jpeg"), denoise.Null(), codecs.RgbJpeg()
+    )
+
+    assert (export_path / topics[0] / "1.json").exists()
+    assert (export_path / topics[1] / "1.json").exists()
+
+    with open(export_path / topics[0] / "1.json", encoding="utf-8") as file:
+        metadata = json.load(file)
+        assert metadata == {
+            "id": 1,
+            "image_info": {"channel_layout": "RGB", "height": "100", "width": "100"},
+            "published_time": 0.0,
+            "source_timestamp": 0.0,
+            "status": 0,
+            "type": "IMAGE",
+        }
 
 
 @pytest.mark.usefixtures("set_alias")


### PR DESCRIPTION
**Closes** DRIFT-684

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

We export only package content without its meta information
 
### What is the new behavior?

I added the flag which works for --jpeg or default export and saves metadata into a JSON file for each package.

### Does this PR introduce a breaking change?

No

### Other information:
