### PR TITLE
Rise an error if --with-metadata used with --csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Rise an error if --with-metadata used with --csv, [PR-14](https://github.com/panda-official/DriftCLI/pull/14)
+
 ## 0.7.0 - 2023-06-26
 
 ### Added

--- a/drift_cli/export.py
+++ b/drift_cli/export.py
@@ -90,6 +90,10 @@ def raw(
         error_console.print("Error: --csv and --jpeg are mutually exclusive")
         raise Abort()
 
+    if with_metadata and csv:
+        error_console.print("Error: --with-metadata is not supported with --csv")
+        raise Abort()
+
     alias_name, _ = parse_path(src)
     alias: Alias = read_config(ctx.obj["config_path"]).aliases[alias_name]
 

--- a/drift_cli/export_impl/raw.py
+++ b/drift_cli/export_impl/raw.py
@@ -233,9 +233,6 @@ async def export_raw(client: DriftClient, dest: str, parallel: int, **kwargs):
             task = _export_csv if kwargs.get("csv", False) else _export_topic
             task = _export_jpeg if kwargs.get("jpeg", False) else task
 
-            if kwargs.get("with_metadata", False) and kwargs.get("csv", False):
-                RuntimeError("Metadata export is not supported for CSV files")
-
             tasks = [
                 task(
                     pool,


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bugfix

### What is the current behavior?

A user gets confused with they use the --csv and --with-metdata flags together. It works but  doesn't provide any metadata.

### What is the new behavior?

The CLI rises an error when both flags are used.

### Does this PR introduce a breaking change?

No

### Other information:
