### PR TITLE
Fix query timeout and improve error messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install --no-cache --upgrade pip setuptools wheel
 
@@ -25,7 +25,7 @@ jobs:
     needs: format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install --no-cache --upgrade pip
 
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python}}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@master
         with:
           name: package
@@ -88,7 +88,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@master
         with:
           name: package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Query timeout and improve error messages, [PR-18](https://github.com/panda-official/DriftCLI/pull/18)
+
 ## 0.9.0 - 2023-09-14
 
 ### Added
 
-- support for TypedData for CSV export, [PR-17](https://github.com/panda-official/DriftCLI/pull/17)
+- Support for TypedData for CSV export, [PR-17](https://github.com/panda-official/DriftCLI/pull/17)
 
 ## 0.8.0 - 2023-07-11
 
 ### Added
 
-- Supports for labels in metadata, [PR-15](https://github.com/panda-official/DriftCLI/pull/15)
+- Support for labels in metadata, [PR-15](https://github.com/panda-official/DriftCLI/pull/15)
 
 ## 0.7.1 - 2023-06-29
 

--- a/drift_cli/export_impl/raw.py
+++ b/drift_cli/export_impl/raw.py
@@ -165,8 +165,6 @@ async def _export_csv(
             return next(it)
         except StopIteration:
             return None
-        except DriftClientError:
-            return None
 
     pkg = await asyncio.get_running_loop().run_in_executor(pool, _next)
     if pkg is None or pkg.meta.type == MetaInfo.TIME_SERIES:
@@ -336,7 +334,7 @@ async def export_raw(client: DriftClient, dest: str, parallel: int, **kwargs):
                     progress,
                     sem,
                     topics=topics,
-                    parallel=parallel // len(topics) + 1,
+                    parallel=min(parallel, len(topics)),
                     **kwargs,
                 )
                 for topic in topics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "drift-python-client~=0.8.1",
+    "drift-python-client~=0.9.0",
     "click~=8.1",
     "tomlkit~=0.11",
     "rich~=12.6",

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -203,6 +203,12 @@ def test__export_raw_data(runner, client, conf, export_path, topics, timeseries)
     assert (export_path / topics[1] / "1.dp").exists()
     assert (export_path / topics[1] / "2.dp").exists()
 
+    assert client.walk.call_count == 2
+    assert client.walk.call_args_list[0][0][0] == topics[0]
+    assert client.walk.call_args_list[0][1]["start"] == 1640991600.0
+    assert client.walk.call_args_list[0][1]["stop"] == 1641078000.0
+    assert client.walk.call_args_list[0][1]["ttl"] == 360
+
 
 @pytest.mark.usefixtures("set_alias")
 def test__export_raw_data_with_metadata(

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -192,7 +192,8 @@ def test__export_raw_data(runner, client, conf, export_path, topics, timeseries)
     """Test export raw data"""
     client.walk.side_effect = [Iterator(timeseries), Iterator(timeseries)]
     result = runner(
-        f"-c {conf} -p 2 export raw test {export_path} --start 2022-01-01T00:00:00Z --stop 2022-01-02T00:00:00Z"
+        f"-c {conf} -p 2 export raw test {export_path} "
+        f"--start 2022-01-01T00:00:00Z --stop 2022-01-02T00:00:00Z"
     )
     assert f"Topic '{topics[0]}' (copied 2 packages (943 B)" in result.output
     assert f"Topic '{topics[1]}' (copied 2 packages (943 B)" in result.output

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -192,7 +192,7 @@ def test__export_raw_data(runner, client, conf, export_path, topics, timeseries)
     """Test export raw data"""
     client.walk.side_effect = [Iterator(timeseries), Iterator(timeseries)]
     result = runner(
-        f"-c {conf} -p 2 export raw test {export_path} --start 2022-01-01 --stop 2022-01-02"
+        f"-c {conf} -p 2 export raw test {export_path} --start 2022-01-01T00:00:00Z --stop 2022-01-02T00:00:00Z"
     )
     assert f"Topic '{topics[0]}' (copied 2 packages (943 B)" in result.output
     assert f"Topic '{topics[1]}' (copied 2 packages (943 B)" in result.output
@@ -205,8 +205,8 @@ def test__export_raw_data(runner, client, conf, export_path, topics, timeseries)
 
     assert client.walk.call_count == 2
     assert client.walk.call_args_list[0][0][0] == topics[0]
-    assert client.walk.call_args_list[0][1]["start"] == 1640991600.0
-    assert client.walk.call_args_list[0][1]["stop"] == 1641078000.0
+    assert client.walk.call_args_list[0][1]["start"] == 1640995200.0
+    assert client.walk.call_args_list[0][1]["stop"] == 1641081600.0
     assert client.walk.call_args_list[0][1]["ttl"] == 360
 
 


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix 

### What is the current behavior?

The CLI uses a hand coded TTL query timeout  of 60 seconds. However, it can be too short for CSV export when we need to extract and save data on a disk because the data comes as batches of many Drift packages. Moreover, this timeout doesn't  consider the number of async tasks which slow down the data processing because it is impossible to extract data in parallel in Python (GIL).  

As result, ReductStore discards  "old" queries and the data downloading stops working.

### What is the new behavior?


I've update the `PythonDriftClient` and added an TTL option, so that the Drift CLI can increase the timeout to 180 x number of downloaded topics.  Additionally, I've added error messages to identify communication problems. 

### Does this PR introduce a breaking change?

No

### Other information:
