### PR TITLE
Add scale option for csv data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--scale` option to `export raw` command, [PR-19](https://github.com/panda-official/DriftCLI/pull/19)
+
 ## 0.9.1 - 2023-12-14
 
 ### Fixed

--- a/drift_cli/__main__.py
+++ b/drift_cli/__main__.py
@@ -1,4 +1,5 @@
 """Entry point"""
+
 from drift_cli import main
 
 if __name__ == "__main__":

--- a/drift_cli/alias.py
+++ b/drift_cli/alias.py
@@ -1,4 +1,5 @@
 """Alias commands"""
+
 from typing import Optional
 
 import click

--- a/drift_cli/cli.py
+++ b/drift_cli/cli.py
@@ -1,4 +1,5 @@
 """Main module"""
+
 from importlib import metadata
 from pathlib import Path
 from typing import Optional

--- a/drift_cli/config.py
+++ b/drift_cli/config.py
@@ -1,4 +1,5 @@
 """Configuration"""
+
 import os
 from pathlib import Path
 from typing import Dict

--- a/drift_cli/export.py
+++ b/drift_cli/export.py
@@ -1,4 +1,5 @@
 """Export Command"""
+
 import asyncio
 
 import click
@@ -61,6 +62,11 @@ def export():
     help="Export metadata along with the data (doesn't work with --csv)",
     default=False,
 )
+@click.option(
+    "--scale",
+    help="Scale factor for data (only for --csv): 0 - no scaling, 1 - 2x, 2 - 4x, ...) ",
+    default=0,
+)
 @click.pass_context
 def raw(
     ctx,
@@ -72,6 +78,7 @@ def raw(
     csv: bool,
     jpeg: bool,
     with_metadata: bool,
+    scale: int,
 ):  # pylint: disable=too-many-arguments
     """Export data from SRC bucket to DST folder
 
@@ -114,5 +121,6 @@ def raw(
                 csv=csv,
                 jpeg=jpeg,
                 with_metadata=with_metadata,
+                scale=scale,
             )
         )

--- a/drift_cli/export_impl/raw.py
+++ b/drift_cli/export_impl/raw.py
@@ -1,4 +1,5 @@
 """Export data"""
+
 import asyncio
 import csv
 import json
@@ -182,6 +183,7 @@ async def _export_csv_timeseries(
     dest: str,
     progress: Progress,
     sem,
+    scale,
     **kwargs,
 ):
     filename = Path(dest) / f"{topic}.csv"
@@ -223,7 +225,9 @@ async def _export_csv_timeseries(
 
         last_timestamp = package.meta.time_series_info.stop_timestamp.ToMilliseconds()
         with open(filename, "a") as file:
-            np.savetxt(file, package.as_np(), delimiter=",", fmt="%.5f")
+            np.savetxt(
+                file, package.as_np(scale_factor=scale), delimiter=",", fmt="%.5f"
+            )
 
         count += 1
 

--- a/drift_cli/utils/consoles.py
+++ b/drift_cli/utils/consoles.py
@@ -1,4 +1,5 @@
 """Rich consoles"""
+
 from rich.console import Console
 
 error_console = Console(stderr=True, style="bold red")

--- a/drift_cli/utils/error.py
+++ b/drift_cli/utils/error.py
@@ -1,4 +1,5 @@
 """Error handling"""
+
 from contextlib import contextmanager
 
 from click import Abort

--- a/drift_cli/utils/helpers.py
+++ b/drift_cli/utils/helpers.py
@@ -1,4 +1,5 @@
 """Helper functions"""
+
 import asyncio
 import signal
 import time

--- a/drift_cli/utils/humanize.py
+++ b/drift_cli/utils/humanize.py
@@ -1,4 +1,5 @@
 """Helper function for readable time intervals and volumes"""
+
 # pylint:disable=too-many-return-statements
 from datetime import datetime, timezone
 from typing import Union, Optional

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures"""
+
 from functools import partial
 from pathlib import Path
 from tempfile import gettempdir

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -1,4 +1,5 @@
 """Export data from SRC bucket to DST bucket"""
+
 import json
 
 # pylint: disable=too-many-arguments


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

We export the whole time series signal to CSV.

### What is the new behavior?

We use `--scale` option to specify scale factor to reduce number of samples by using partitional wavelet composition. 

### Does this PR introduce a breaking change?

No

### Other information:
