### PR TITLE
Check status before meta info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Check status before meta information, [PR-20](https://github.com/panda-official/DriftCLI/pull/20)
+
 ## 0.10.0 - 2024-03-26
 
 ### Added

--- a/drift_cli/export_impl/raw.py
+++ b/drift_cli/export_impl/raw.py
@@ -264,6 +264,10 @@ async def _export_csv_typed_data(
         async for package, task in read_topic(
             pool, client, topic, progress, sem, **kwargs
         ):
+
+            if package.status_code != 0:
+                continue
+
             meta = package.meta
             if meta.type != MetaInfo.TYPED_DATA:
                 progress.update(
@@ -272,9 +276,6 @@ async def _export_csv_typed_data(
                     completed=True,
                 )
                 break
-
-            if package.status_code != 0:
-                continue
 
             fields = {"timestamp": package.package_id}
 


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

Packages with a bad status may not have meta -info. But the tool checks it first.
Now it checks the status and skip bad packages


### Does this PR introduce a breaking change?

No

### Other information:
